### PR TITLE
Added Base path, Host & schemes of Swagger UI

### DIFF
--- a/lib/apidocToSwagger.js
+++ b/lib/apidocToSwagger.js
@@ -10,6 +10,9 @@ var swagger = {
 
 function toSwagger(apidocJson, projectJson) {
 	swagger.info = addInfo(projectJson);
+	swagger.basePath = projectJson.basePath;
+	swagger.host = projectJson.host;
+	swagger.schemes = projectJson.schemes;
 	swagger.paths = extractPaths(apidocJson);
 	return swagger;
 }


### PR DESCRIPTION
When I converted apiDoc to Swagger json, I could not find where to add my Swagger base path, host & schemes. I needed these values because I wanted to run the API in the Swagger UI. I traversed code and found the place and added the lines. In apidoc.json you need to provide these things in below format.

"host" : "{API Host Name}",
"basePath" : "{Base Path}",
"schemes" : ["https","http"]